### PR TITLE
Add ExpectedStatefulSets in reconcile pkg

### DIFF
--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func ExpectedStatefulSets(ctx context.Context, params Params, expected []appsv1.StatefulSet) error {
+	for _, obj := range expected {
+		desired := obj
+
+		if err := controllerutil.SetControllerReference(&params.Instance, &desired, params.Scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+
+		existing := &appsv1.StatefulSet{}
+		nns := types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}
+		err := params.Client.Get(ctx, nns, existing)
+		if err != nil && k8serrors.IsNotFound(err) {
+			if err := params.Client.Create(ctx, &desired); err != nil {
+				return fmt.Errorf("failed to create: %w", err)
+			}
+			params.Log.V(2).Info("created", "statefulset.name", desired.Name, "statefulset.namespace", desired.Namespace)
+			continue
+		} else if err != nil {
+			return fmt.Errorf("failed to get: %w", err)
+		}
+
+		// it exists already, merge the two if the end result isn't identical to the existing one
+		updated := existing.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		if updated.Labels == nil {
+			updated.Labels = map[string]string{}
+		}
+
+		updated.Spec = desired.Spec
+		updated.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
+
+		for k, v := range desired.ObjectMeta.Annotations {
+			updated.ObjectMeta.Annotations[k] = v
+		}
+		for k, v := range desired.ObjectMeta.Labels {
+			updated.ObjectMeta.Labels[k] = v
+		}
+
+		patch := client.MergeFrom(&params.Instance)
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
+			return fmt.Errorf("failed to apply changes: %w", err)
+		}
+
+		params.Log.V(2).Info("applied", "statefulset.name", desired.Name, "statefulset.namespace", desired.Namespace)
+	}
+
+	return nil
+}

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func ExpectedStatefulSets(ctx context.Context, params Params, expected []appsv1.StatefulSet) error {
+func expectedStatefulSets(ctx context.Context, params Params, expected []appsv1.StatefulSet) error {
 	for _, obj := range expected {
 		desired := obj
 

--- a/pkg/collector/reconcile/statefulset_test.go
+++ b/pkg/collector/reconcile/statefulset_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconcile_test
+package reconcile
 
 import (
 	"context"
@@ -29,7 +29,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/reconcile"
 )
 
 var logger = logf.Log.WithName("unit-tests")
@@ -82,7 +81,7 @@ func TestExpectedStatefulSets(t *testing.T) {
 			UID:       existing.UID,
 		},
 	}
-	params := reconcile.Params{
+	params := Params{
 		Client:   k8sClient,
 		Log:      logger,
 		Scheme:   testScheme,
@@ -130,7 +129,7 @@ func TestExpectedStatefulSets(t *testing.T) {
 		},
 	}
 
-	err = reconcile.ExpectedStatefulSets(context.Background(), params, update)
+	err = expectedStatefulSets(context.Background(), params, update)
 	require.NoError(t, err)
 
 	opts := []client.ListOption{

--- a/pkg/collector/reconcile/statefulset_test.go
+++ b/pkg/collector/reconcile/statefulset_test.go
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/reconcile"
+)
+
+var logger = logf.Log.WithName("unit-tests")
+
+func TestExpectedStatefulSets(t *testing.T) {
+	// prepare
+	var prev_replicas int32 = 3
+	var new_replicas int32 = 4
+	cfg := config.New()
+	nsn := types.NamespacedName{Name: "existingstatefulset", Namespace: "default"}
+	labels := client.MatchingLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "opentelemetry-operator",
+	})
+
+	// First create a StatefulSet instance in the client as the "existing" instance
+	existed := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsn.Name,
+			Namespace: nsn.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &prev_replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), existed)
+	require.NoError(t, err)
+
+	existing := &appsv1.StatefulSet{}
+	err = k8sClient.Get(context.Background(), nsn, existing)
+	require.NoError(t, err)
+	// Make sure the existing StatefulSet has a Replica of 3.
+	assert.Equal(t, prev_replicas, *existing.Spec.Replicas)
+
+	// Create a fake OpenTelemetryCollector object so we can
+	// pass in Name and UID of the existing StatefulSet into
+	// ExpectedStatefulSets()
+	instance := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsn.Name,
+			Namespace: nsn.Namespace,
+			UID:       existing.UID,
+		},
+	}
+	params := reconcile.Params{
+		Client:   k8sClient,
+		Log:      logger,
+		Scheme:   testScheme,
+		Config:   cfg,
+		Instance: instance,
+	}
+
+	// We will pass in two StatefulSets to ExpectedStatefulSets().
+	// One will update the existing StatefulSet's replica to 4, and
+	// the other will create a new StatefulSet.
+	update := []appsv1.StatefulSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &new_replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "newstatefulset",
+				Namespace: nsn.Namespace,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &new_replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+				},
+			},
+		},
+	}
+
+	err = reconcile.ExpectedStatefulSets(context.Background(), params, update)
+	require.NoError(t, err)
+
+	opts := []client.ListOption{
+		client.InNamespace(nsn.Namespace),
+	}
+
+	list := &appsv1.StatefulSetList{}
+	err = k8sClient.List(context.Background(), list, opts...)
+	assert.NoError(t, err)
+
+	assert.Len(t, list.Items, 2)
+	assert.Equal(t, nsn.Name, list.Items[0].Name)
+	// The existing StatefulSet now should have a Replica of 4.
+	assert.Equal(t, new_replicas, *list.Items[0].Spec.Replicas)
+
+	assert.Equal(t, "newstatefulset", list.Items[1].Name)
+	assert.Equal(t, new_replicas, *list.Items[1].Spec.Replicas)
+
+	// cleanup
+	require.NoError(t, k8sClient.Delete(context.Background(), &list.Items[0]))
+	require.NoError(t, k8sClient.Delete(context.Background(), &list.Items[1]))
+
+}

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconcile_test
+package reconcile
 
 import (
 	"fmt"

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme = scheme.Scheme
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err := v1alpha1.AddToScheme(testScheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}


### PR DESCRIPTION
Add ExpectedStatefulSets and unit tests to the reconcile pkg. This a step of resovling [#31](https://github.com/open-telemetry/wg-prometheus/issues/31) and [#35](https://github.com/open-telemetry/opentelemetry-operator/issues/35). 