### PR TITLE
Add `protocol: TCP` value under `ports` key to avoid the known limitation for Kubernetes 1.19

### DIFF
--- a/bundle/manifests/opentelemetry-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/opentelemetry-operator-controller-manager-metrics-service_v1_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/bundle/manifests/opentelemetry-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/opentelemetry-operator-webhook-service_v1_service.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community
-  name: opentelemetry-operator.v0.24.0-59-g12890f9
+  name: opentelemetry-operator.v0.31.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -206,7 +206,7 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                image: controller
+                image: quay.io/opentelemetry/opentelemetry-operator:v0.31.0
                 name: manager
                 ports:
                 - containerPort: 9443
@@ -298,7 +298,7 @@ spec:
   maturity: alpha
   provider:
     name: OpenTelemetry Community
-  version: 0.24.0-59-g12890f9
+  version: 0.31.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community
-  name: opentelemetry-operator.v0.31.0
+  name: opentelemetry-operator.v0.24.0-59-g12890f9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -206,7 +206,7 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                image: quay.io/opentelemetry/opentelemetry-operator:v0.31.0
+                image: controller
                 name: manager
                 ports:
                 - containerPort: 9443
@@ -233,6 +233,7 @@ spec:
                 ports:
                 - containerPort: 8443
                   name: https
+                  protocol: TCP
                 resources: {}
               serviceAccountName: opentelemetry-operator-controller-manager
               terminationGracePeriodSeconds: 10
@@ -297,7 +298,7 @@ spec:
   maturity: alpha
   provider:
     name: OpenTelemetry Community
-  version: 0.31.0
+  version: 0.24.0-59-g12890f9
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,6 +19,7 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+          protocol: TCP
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -10,5 +10,6 @@ spec:
   - name: https
     port: 8443
     targetPort: https
+    protocol: TCP
   selector:
     control-plane: controller-manager

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -8,5 +8,6 @@ spec:
   ports:
     - port: 443
       targetPort: 9443
+      protocol: TCP
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
This PR adds protocol: TCP value under ports key. This should resolve the error caused by a known limitation of Kubernetes 1.19 and eariler.